### PR TITLE
Update sen2cor 2.10 -> 2.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,9 @@
 FROM ubuntu:20.04
 
-# https://step.esa.int/thirdparties/sen2cor/2.10.0/Sen2Cor-02.10.01-Linux64.run
-ENV SEN2COR_VER=02.10.01
-ENV SEN2COR_VER_SHORT=2.10.0
-ENV SEN2COR_VER_MINI=2.10
-
-# v2.11 is broken :(
 ## https://step.esa.int/thirdparties/sen2cor/2.11.0/Sen2Cor-02.11.00-Linux64.run
-#ENV SEN2COR_VER=02.11.00
-#ENV SEN2COR_VER_SHORT=2.11.0
-#ENV SEN2COR_VER_MINI=2.11
+ENV SEN2COR_VER=02.11.00
+ENV SEN2COR_VER_SHORT=2.11.0
+ENV SEN2COR_VER_MINI=2.11
 
 WORKDIR /opt
 


### PR DESCRIPTION
The original sen2cor 2.11 was broken, now an update (same version number!) has been published:

- sen2Cor 2.11 Linux installer update: https://step.esa.int/main/2077-2/
- discussion: https://forum.step.esa.int/t/sen2cor-2-11-0-linking-to-musl-is-causing-issues-on-modern-linux-distros/38437/16

This PR updates the Dockerfile to v2.11.